### PR TITLE
fixing spikespray data flow and other misc fixes

### DIFF
--- a/client/src/actions/actionCreators.js
+++ b/client/src/actions/actionCreators.js
@@ -51,6 +51,27 @@ export const createFetchAPI = async url => {
   }
 };
 
+// export const createFetchUnitDetailApi = async url => {
+//   const newUrl = baseurl + url;
+//   try {
+//     const response = await axios.get(newUrl);
+//     const returned = await response.data;
+//     if (response.status !== 200) Sentry.captureException(returned.message);
+//     if (returned.unitDetail.spikeSprayUrl) {
+//       let response2 = await axios.get(returned.unitDetail.spikeSprayUrl)
+//       const returned2 = await response2.data;
+//       if (response.status !== 200) Sentry.captureException(returned2.message);
+//       returned.unitDetail.spikeSprayData = returned2.data;
+//       return returned;
+//     }
+//     else {
+//       return returned;
+//     }
+//   } catch (error) {
+//     Sentry.captureException(error);
+//   }
+// };
+
 export const createFetchPost = async (url, options) => {
   try {
     const newUrl = baseurl + url;
@@ -92,7 +113,7 @@ export function sendContactFailure(error) {
 }
 
 export const sendContact = options => {
-  return function(dispatch) {
+  return function (dispatch) {
     return createFetchPost(`/api/contact`, options)
       .then(res => {
         dispatch(sendContactSuccess(res.success));
@@ -111,7 +132,7 @@ export const receiveStudies = studies => ({
 
 export const fetchStudies = () => {
   let url = `/api/studies`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(res => {
@@ -134,7 +155,7 @@ export const receiveCPUs = cpus => {
 
 export const fetchCPUs = () => {
   let url = `/api/cpus`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(res => {
@@ -157,7 +178,7 @@ export const receiveGroupedURs = groupedURs => {
 
 export const fetchGroupedURs = () => {
   let url = `/api/groupedurs`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(res => {
@@ -180,7 +201,7 @@ export const receiveURsByStudy = ursByStudy => {
 
 export const fetchURsByStudy = name => {
   let url = `/api/ursbystudy/` + name;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(res => {
@@ -203,7 +224,7 @@ export const receiveUnitResults = unitresults => {
 
 export const fetchUnitResults = () => {
   let url = `/api/unitresults`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(unitresults => {
@@ -223,7 +244,7 @@ export const receiveSorters = sorters => ({
 
 export const fetchSorters = () => {
   let url = `/api/sorters`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(res => {
@@ -246,7 +267,7 @@ export const receiveAlgorithms = algorithms => ({
 
 export const fetchAlgorithms = () => {
   let url = `/api/algorithms`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(res => {
@@ -282,7 +303,7 @@ export const recieveStats = stats => {
 
 export const fetchStats = () => {
   let url = `/api/stats`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(stats => {
@@ -304,7 +325,7 @@ export const recieveStudySets = studysets => {
 
 export const fetchStudySets = () => {
   let url = `/api/studysets`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(studysets => {
@@ -326,7 +347,7 @@ export const receiveRecordings = recordings => {
 
 export const fetchRecordings = () => {
   let url = `/api/recordings`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(recordings => {
@@ -339,10 +360,12 @@ export const fetchRecordings = () => {
 };
 
 // Study analysis results
-export const receiveStudyAnalysisResults = studyAnalysisResults => ({
-  type: RECEIVE_STUDY_ANALYSIS_RESULTS,
-  studyAnalysisResults
-});
+export const receiveStudyAnalysisResults = studyAnalysisResults => {
+  return {
+    type: RECEIVE_STUDY_ANALYSIS_RESULTS,
+    studyAnalysisResults
+  }
+};
 
 export const fetchStudyAnalysisResults = () => {
   let url = `/api/studyanalysisresults`;
@@ -369,7 +392,7 @@ export const receiveUnitDetail = unitDetail => {
 
 export const fetchUnitDetail = (studyName, recordingName, sorterName, trueUnitId) => {
   let url = `/api/unitdetail/${studyName}/${recordingName}/${sorterName}/${trueUnitId}`;
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchAPI(url)
       .then(res => {
@@ -381,7 +404,6 @@ export const fetchUnitDetail = (studyName, recordingName, sorterName, trueUnitId
       .catch(err => Sentry.captureException(err));
   };
 };
-
 
 // Selected Study for Scatterplot
 export const selectStudySortingResult = studySortingResult => ({
@@ -411,7 +433,7 @@ export const fetchSpikeSpray = url => {
   // TODO: Remove when other spikes are live and use passed in URL
   const defaultUrl =
     "http://kbucket.flatironinstitute.org/get/sha1/0aa39927530abed94f32c410f3a2226e2ee71c5e?signature=c516794c53257b327f39b8349cc39313f1a254e9";
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch(startLoading());
     return createFetchKBucket(defaultUrl)
       .then(spikespray => {

--- a/client/src/components/DetailPage/DetailPage.js
+++ b/client/src/components/DetailPage/DetailPage.js
@@ -214,7 +214,10 @@ class DetailPage extends Component {
                     <div className="content">
                       <div className="card__label">
                         <p>
-                          <strong>Unit Details: </strong>
+                          {this.state.selectedUnit ?
+                            (<strong>Unit Details: {`${this.props.studyName}/${studyAnalysisResult.recordingNames[studyAnalysisResult.trueRecordingIndices[this.state.selectedUnit.unitIndex]]}/${this.state.selectedUnit.sorterName}/${studyAnalysisResult.trueUnitIds[this.state.selectedUnit.unitIndex]}`}</strong>) :
+                            (<strong>Unit Details:</strong>)
+                          }
                         </p>
                       </div>
                       {(() => {

--- a/client/src/components/DetailPage/SpikeSpray.js
+++ b/client/src/components/DetailPage/SpikeSpray.js
@@ -118,15 +118,24 @@ class SpikeSpray extends Component {
 
   render() {
     let loading = isEmpty(this.state.spikeObjArr);
+    let totalTrue = this.props.numMatches + this.props.numFalseNegatives;
+    let totalSorted = this.props.numMatches + this.props.numFalsePositives;
     let colTitles = {
-      true: "Groundtruth",
+      true: "Ground truth",
       sorted: "Sorted",
-      true_missed: "True Missed / False Positive",
-      sorted_false: "Sorted False / False Negative"
+      true_missed: "False negatives",
+      sorted_false: "False positives"
     };
-    let totalSpikes = isEmpty(this.state.spikeObjArr)
-      ? 0
-      : this.state.spikeObjArr[0].num_spikes;
+    let colTotals = {
+      true: totalTrue,
+      sorted: totalSorted,
+      true_missed: this.props.numFalseNegatives,
+      sorted_false: this.props.numFalsePositives
+    };
+    // let totalSpikes = isEmpty(this.state.spikeObjArr)
+    //   ? 0
+    //   : this.state.spikeObjArr[0].num_spikes;
+    
     return (
       <div>
         {loading ? (
@@ -145,7 +154,7 @@ class SpikeSpray extends Component {
                   <div className="card__label">
                     <p className="card__charttitle">
                       {colTitles[column.name]} <br />
-                      {column.num_spikes} of {totalSpikes} spikes shown
+                      {column.num_spikes} of {colTotals[column.name]} spikes shown
                     </p>
                   </div>
                   <XYPlot

--- a/client/src/components/DetailPage/UnitDetail.js
+++ b/client/src/components/DetailPage/UnitDetail.js
@@ -6,63 +6,25 @@ import { connect } from "react-redux";
 import * as actionCreators from "../../actions/actionCreators";
 import SpikeSpray from "./SpikeSpray";
 
-import { Card, Col, Container, Row } from "react-bootstrap";
-import loading from "../../reducers/loading";
+import { Container, Row } from "react-bootstrap";
+// import loading from "../../reducers/loading";
 
-const axios = require("axios");
+// const axios = require("axios");
 
 class UnitDetail extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      unitDetail: null,
-      spikeSprayData: null,
-      unitDetailLoaded: false,
-      spikeSprayLoaded: false
-    };
-  }
+  // constructor(props) {
+  //   super(props);
+  // }
 
   componentDidMount() {
-    this.fetchUnitDetail();
+    let unitData = this.getUnitData();
+    this.props.fetchUnitDetail(unitData.studyName, unitData.recordingName, unitData.sorterName, unitData.unitId);
   }
 
   componentDidUpdate(prevProps, prevState) {
     if ((this.props.studyAnalysisResult !== prevProps.studyAnalysisResult) || (this.props.unitIndex !== prevProps.unitIndex) || (this.props.sorterName !== prevProps.sorterName)) {
-      this.setState({unitDetailLoaded: false});
-      this.fetchUnitDetail();
-    }
-    else {
-      if (this.state.unitDetail !== prevState.unitDetail) {
-        this.setState({spikeSprayLoaded: false});
-        this.fetchSpikeSpray();
-      }
-    }
-  }
-
-  async fetchUnitDetail() {
-    let baseurl;
-    if (process.env.NODE_ENV === "production") {
-      baseurl = "https://spikeforestfront.herokuapp.com";
-    } else {
-      baseurl = "http://localhost:5000";
-    }
-
-    let unitData = this.getUnitData()
-    let result = await fetchUrl(baseurl + `/api/unitdetail/${unitData.studyName}/${unitData.recordingName}/${unitData.sorterName}/${unitData.unitId}`, 3000);
-    if (result)
-      this.setState({unitDetail: result.unitDetail});
-    else
-      this.setState({unitDetail: null});
-    this.setState({unitDetailLoaded: true});
-  }
-
-  async fetchSpikeSpray() {
-    let udet = this.state.unitDetail;
-    if (!udet) return;
-    if (udet.spikeSprayUrl) {
-      let data = await fetchUrl(udet.spikeSprayUrl);
-      this.setState({spikeSprayData: data});
-      this.setState({spikeSprayLoaded: true});
+      let unitData = this.getUnitData();
+      this.props.fetchUnitDetail(unitData.studyName, unitData.recordingName, unitData.sorterName, unitData.unitId);
     }
   }
 
@@ -77,6 +39,7 @@ class UnitDetail extends Component {
     });
     let recind = sar.trueRecordingIndices[uind];
     let unitData = {
+        udpath: `${sar.studyName}/${sar.recordingNames[recind]}/${sorterName}/${sar.trueUnitIds[uind]}`,
         studyName: sar.studyName,
         recordingName: sar.recordingNames[recind],
         sorterName: sorterName,
@@ -86,6 +49,9 @@ class UnitDetail extends Component {
         numEvents: sar.trueNumEvents[uind],
         accuracy: sortingResult.accuracies[uind],
         precision: sortingResult.precisions[uind],
+        numMatches: sortingResult.numMatches[uind],
+        numFalsePositives: sortingResult.numFalsePositives[uind],
+        numFalseNegatives: sortingResult.numFalseNegatives[uind],
         recall: sortingResult.recalls[uind]
     }
     return unitData;
@@ -93,31 +59,30 @@ class UnitDetail extends Component {
 
   render() {
     let unitData = this.getUnitData()
+    let udpath = unitData.udpath;
     let loading_message = null;
-    if (!this.state.unitDetailLoaded) {
+    if (!this.props.unitDetail) {
       loading_message = 'Loading unit detail...';
     }
-    else if (!this.state.spikeSprayLoaded) {
-      if (!this.state.unitDetail) {
-        loading_message = 'No unit detail found.';
-      }
-      else {
-        loading_message = 'Loading spike spray...';
-      }
+    else if (!this.props.unitDetail[udpath]) {
+      loading_message = 'Loading unit detail......';
     }
     else {
-      if (!this.state.spikeSprayData) {
+      if (!this.props.unitDetail[udpath].spikeSprayUrl) {
         loading_message = 'No spike spray found.'
+      }
+      else if (!this.props.unitDetail[udpath].spikeSprayData) {
+        loading_message = 'No spike spray data found.'
       }
     }
     return (
         <Container>
-          <Row>{JSON.stringify(unitData, null, 4)}</Row>
+          {/* <Row>{JSON.stringify(unitData, null, 4)}</Row> */}
           <Row>
             {
               (loading_message) ?
               (<span>{loading_message}</span>) :
-              (<SpikeSpray spikeSprayData={this.state.spikeSprayData}></SpikeSpray>)
+              (<SpikeSpray spikeSprayData={this.props.unitDetail[udpath].spikeSprayData} numMatches={unitData.numMatches} numFalsePositives={unitData.numFalsePositives} numFalseNegatives={unitData.numFalseNegatives}></SpikeSpray>)
             }
           </Row>
         </Container>
@@ -125,23 +90,6 @@ class UnitDetail extends Component {
     )
   }
 }
-
-const fetchUrl = async (url, timeout) => {
-  try {
-    const response = await axios.get(url, {timeout: timeout});
-    if (response.status !== 200) {
-      // Sentry.captureException(response.message);
-      console.error(response.message);
-      return null;
-    } else {
-      return response.data;
-    }
-  } catch (error) {
-    // Sentry.captureException(error);
-    console.error(error);
-    return null;
-  }
-};
 
 function mapStateToProps(state) {
   return {

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -3,7 +3,7 @@ import { LinkContainer } from "react-router-bootstrap";
 
 import { Nav, Navbar } from "react-bootstrap";
 import logo from "./logo-no-icon.svg";
-import InfoPanel from "./InfoPanel";
+// import InfoPanel from "./InfoPanel";
 
 import { toTitleCase } from "../../utils";
 

--- a/client/src/components/Heatmap/HeatmapViz.js
+++ b/client/src/components/Heatmap/HeatmapViz.js
@@ -194,6 +194,9 @@ class HeatmapViz extends Component {
         accuracies: [],
         precisions: [],
         recalls: [],
+        numMatches: [],
+        numFalsePositives: [],
+        numFalseNegatives: [],
         cpuTimesSec: []
       });
     }
@@ -207,6 +210,9 @@ class HeatmapViz extends Component {
         sortingResults[ii].accuracies = sortingResults[ii].accuracies.concat(studyAnalysisResult.sortingResults[ii].accuracies);
         sortingResults[ii].precisions = sortingResults[ii].precisions.concat(studyAnalysisResult.sortingResults[ii].precisions);
         sortingResults[ii].recalls = sortingResults[ii].recalls.concat(studyAnalysisResult.sortingResults[ii].recalls);
+        sortingResults[ii].numMatches = sortingResults[ii].numMatches.concat(studyAnalysisResult.sortingResults[ii].numMatches);
+        sortingResults[ii].numFalsePositives = sortingResults[ii].numFalsePositives.concat(studyAnalysisResult.sortingResults[ii].numFalsePositives);
+        sortingResults[ii].numFalseNegatives = sortingResults[ii].numFalseNegatives.concat(studyAnalysisResult.sortingResults[ii].numFalseNegatives);
         sortingResults[ii].cpuTimesSec = sortingResults[ii].cpuTimesSec.concat(studyAnalysisResult.sortingResults[ii].cpuTimesSec);
       }
     })
@@ -538,26 +544,25 @@ class HeatmapViz extends Component {
               <span>
                 <p style={divStyle}>
                   {
-                    this.props.format == 'cpu' ?
+                    this.props.format === 'cpu' ?
                     (
-                      <span>Note: These numbers reflect actual compute times on our cluster and are not meant to be a rigorous benchmark. The algorithms were applied in batches, with many different algorithms possibly running
+                      <span>These numbers reflect actual compute times on our cluster and are not meant to be a rigorous benchmark. The algorithms were applied in batches, with many different algorithms possibly running
                         simultaneously on the same machine. Some runs may have been allocated more CPU cores than others. We are working toward a more accurate compute time test.
                       </span>
                     ) :
                     (
-                      <span>Note: These are preliminary results prior to parameter optimization, and we still in the process of ensuring that we are using the proper <Link to="/algorithms">versions of the spike sorters</Link>.</span>
+                      <span>These are preliminary results prior to parameter optimization, and we are still in the process of ensuring that we are using the proper <Link to="/algorithms">versions of the spike sorters</Link>.</span>
                     )
                   }
                 </p>
                 <p>
-                  Click to expand study set rows and see component study data. {copy} An asterisk indicates an incomplete or failed sorting on a subset of results.
-                </p>
+                  Click to expand study set rows and see component study data. {copy} * An asterisk indicates an incomplete or failed sorting on a subset of results.</p>
               </span>
             ) :
             (
-              <p>
-                {copy} An asterisk indicates an incomplete or failed sorting on a subset of results.
-              </p>
+              <span>
+                <p>{copy} * An asterisk indicates an incomplete or failed sorting on a subset of results.</p>
+              </span>
             )
           }
         </div>

--- a/client/src/components/Pages/Algorithms.js
+++ b/client/src/components/Pages/Algorithms.js
@@ -45,6 +45,9 @@ class Algorithms extends Component {
           alg.dockerfile
         )}</a>`;
       }
+      else if (alg.environment) {
+        row.environment = '<span>alg.environment</span>';
+      }
       if (alg.wrapper) {
         row.wrapper = `<a href="${alg.wrapper}" target="_blank">${basename(alg.wrapper)}</a>`;
       }

--- a/client/src/components/Pages/Metrics.js
+++ b/client/src/components/Pages/Metrics.js
@@ -8,11 +8,11 @@ class Metrics extends Component {
   render() {
     const groundtruth =
       "n_{{  \\rm match } }^k \\; := \\; \\{ i: |t_j^k-s_i| < \\Delta t  \\mbox{ for some }\\ j \\}";
-    let divStyle = {
-      backgroundColor: "#fffdc0",
-      borderRadius: "5px",
-      display: "inline-block"
-    };
+    // let divStyle = {
+    //   backgroundColor: "#fffdc0",
+    //   borderRadius: "5px",
+    //   display: "inline-block"
+    // };
     return (
       <div className="page__body">
         <Container className="container__heatmap">

--- a/client/src/components/ScatterplotBits/ScatterplotCount.js
+++ b/client/src/components/ScatterplotBits/ScatterplotCount.js
@@ -20,7 +20,7 @@ class ScatterplotCount extends Component {
     this.state = {
       data: [],
       hoveredNode: null,
-      selectedNode: null,
+      selectedUnitCode: null,
       minSNR: 0,
       maxSNR: 100
     };
@@ -98,6 +98,7 @@ class ScatterplotCount extends Component {
             unitIndex: ii, // this is the part that is used in the parent component
             sorterName: this.props.sorterName, // this is used by parent component also
             unitId: sar.trueUnitIds[ii],
+            unitCode: `${sar.studyName}/${sar.recordingNames[sar.trueRecordingIndices[ii]]}/${this.props.sorterName}/${sar.trueUnitIds[ii]}`,
             x: Math.round(snrs[ii] * 100) / 100,
             y: yvals[ii],
             size: Math.max(1, this.getSqrt(sar.trueNumEvents[ii])),
@@ -152,13 +153,13 @@ class ScatterplotCount extends Component {
 
   handleScatterplotClick(d) {
     if (this.props.handleScatterplotClick) {
-      this.setState({selectedNode: d});
+      this.setState({selectedUnitCode: d.unitCode});
       this.props.handleScatterplotClick(d);
     }
   }
 
   render() {
-    const { data, hoveredNode, selectedNode, maxSNR } = this.state;
+    const { data, hoveredNode, selectedUnitCode, maxSNR } = this.state;
     let metricObj = {};
     metricObj[this.props.metric] = hoveredNode ? hoveredNode.y : 0;
     let otherObj = {
@@ -183,6 +184,13 @@ class ScatterplotCount extends Component {
         { x: this.props.sliderValue, y: 0 },
         { x: this.props.sliderValue, y: 1 }
       ];
+    }
+    let selectedNode = null;
+    if (selectedUnitCode) {
+      data.forEach(a => {
+        if (a.unitCode === selectedUnitCode)
+          selectedNode = JSON.parse(JSON.stringify(a));
+      })
     }
     // let selectedData = [];
     const yTitle = toTitleCase(this.props.metric);

--- a/client/src/reducers/unitdetail.js
+++ b/client/src/reducers/unitdetail.js
@@ -4,7 +4,10 @@ import { initialState } from "./initialState";
 const unitDetail = (state = initialState, action) => {
   switch (action.type) {
     case RECEIVE_UNIT_DETAIL:
-      return action.unitDetail;
+      let ud = action.unitDetail;
+      let a = state.unitDetail || {};
+      a[`${ud.studyName}/${ud.recordingName}/${ud.sorterName}/${ud.trueUnitId}`] = action.unitDetail;
+      return a;
     default:
       return state;
   }

--- a/controllers/unitDetailController.js
+++ b/controllers/unitDetailController.js
@@ -1,7 +1,8 @@
 const mongoose = require("mongoose");
 const UnitDetail = mongoose.model("UnitDetail"); //Singleton from mongoose
+const axios = require("axios");
 
-exports.getUnitDetail = async (req, res) => {
+exports.getUnitDetail = async (req, res, next) => {
   const unitDetail = await UnitDetail.findOne({
         studyName: req.params.studyName,
         recordingName: req.params.recordingName,
@@ -9,8 +10,26 @@ exports.getUnitDetail = async (req, res) => {
         trueUnitId: req.params.trueUnitId
     });
   if (!unitDetail) {
-    return next();
+    res.send({ unitDetail: {
+      studyName: req.params.studyName,
+      recordingName: req.params.recordingName,
+      sorterName: req.params.sorterName,
+      trueUnitId: req.params.trueUnitId
+    } });  
+    return;
   }
-  res.send({ unitDetail: unitDetail });
+  let unitDetail2 = JSON.parse(JSON.stringify(unitDetail));
+  if ((unitDetail2.spikeSprayUrl) && (!unitDetail2.spikeSprayData)) {
+    let response = await axios.get(unitDetail2.spikeSprayUrl);
+    const returned = await response.data;
+    if (response.status !== 200) {
+      console.log(`Error retrieving spike spray data from ${unitDetail2.spikeSprayUrl}`);
+      console.error(returned.message);
+    }
+    else {
+      unitDetail2.spikeSprayData = returned;
+    }
+  }
+  res.send({ unitDetail: unitDetail2 });
 };
 

--- a/models/Algorithm.js
+++ b/models/Algorithm.js
@@ -9,6 +9,9 @@ const algorithmSchema = new mongoose.Schema({
   dockerfile: {
     type: String
   },
+  environment: {
+    type: String
+  },
   website: {
     type: String
   },

--- a/models/StudyAnalysisResult.js
+++ b/models/StudyAnalysisResult.js
@@ -1,54 +1,65 @@
 const mongoose = require("mongoose");
 mongoose.Promise = global.Promise;
 
-const studyAnalysisResultSchema = new mongoose.Schema({
-  studyName: {
-    type: String,
-    required: "Name of the study."
-  },
-  recordingNames: {
-    type: [String],
-    required: "Names of the recordings in the study"
-  },
-  trueSnrs: {
-    type: [Number],
-    required: "SNRS of the true units"
-  },
-  trueFiringRates: {
-    type: [Number],
-    required: "firing rates of the true units"
-  },
-  trueNumEvents: {
-    type: [Number],
-    required: "num events of the true units"
-  },
-  trueRecordingIndices: {
-    type: [Number],
-    required: "recording indices of the true units"
-  },
-  trueUnitIds: {
-    type: [Number],
-    required: "unit ids of the true units"
-  },
-  sortingResults: {
-    type: [{
-        sorterName: {
-            type: String
-        },
-        accuracies: {
+const studyAnalysisResultSchema = new mongoose.Schema(
+  {
+    studyName: {
+      type: String,
+      required: "Name of the study."
+    },
+    recordingNames: {
+      type: [String],
+      required: "Names of the recordings in the study"
+    },
+    trueSnrs: {
+      type: [Number],
+      required: "SNRS of the true units"
+    },
+    trueFiringRates: {
+      type: [Number],
+      required: "firing rates of the true units"
+    },
+    trueNumEvents: {
+      type: [Number],
+      required: "num events of the true units"
+    },
+    trueRecordingIndices: {
+      type: [Number],
+      required: "recording indices of the true units"
+    },
+    trueUnitIds: {
+      type: [Number],
+      required: "unit ids of the true units"
+    },
+    sortingResults: {
+      type: [{
+          sorterName: {
+              type: String
+          },
+          accuracies: {
+              type: [Number]
+          },
+          precisions: {
+              type: [Number]
+          },
+          recalls: {
+              type: [Number]
+          },
+          numMatches: {
             type: [Number]
-        },
-        precisions: {
+          },
+          numFalsePositives: {
+              type: [Number]
+          },
+          numFalseNegatives: {
             type: [Number]
-        },
-        recalls: {
+          },
+          cpuTimesSec: {
             type: [Number]
-        },
-        cpuTimesSec: {
-          type: [Number]
-        }
-    }]
+          }
+      }]
+    },  
   }
-});
+);
 
 module.exports = mongoose.model("StudyAnalysisResult", studyAnalysisResultSchema);

--- a/models/UnitDetail.js
+++ b/models/UnitDetail.js
@@ -22,6 +22,10 @@ const unitDetailSchema = new mongoose.Schema(
     },  
     spikeSprayUrl: {
       type: String
+    },
+    spikeSprayData: {
+      type: String,
+      required: false
     }
   },
   {


### PR DESCRIPTION
new system for grabbing spike spray data from server. In particular we do the http requests on the server side. This is important for http requests (when site is deployed to https) -- and/or if auth is required.

Bring through numMatches, numFalsePostives, numFalseNegatives in order to report titles properly on spike sprays

